### PR TITLE
Fix: 모바일 환경 2중 스크롤 현상과 아이폰에서 X축 스크롤이 생기는 이슈 수정

### DIFF
--- a/src/components/molecules/StickyButton.tsx
+++ b/src/components/molecules/StickyButton.tsx
@@ -20,7 +20,9 @@ const stickyStyle = css`
   justify-content: flex-end;
   ${mediaQuery(767)} {
     width: 100%;
-    position: absolute;
+    position: fixed;
+    padding: 24px;
+    box-sizing: border-box;
   }
   right: 0;
   left: 0;

--- a/src/components/organisms/Sidebar.tsx
+++ b/src/components/organisms/Sidebar.tsx
@@ -36,7 +36,7 @@ function Sidebar({
     }
 
     return () => document.body.removeAttribute('style')
-  }, [])
+  }, [isMobile])
 
   return (
     <>

--- a/src/components/organisms/Sidebar.tsx
+++ b/src/components/organisms/Sidebar.tsx
@@ -126,7 +126,7 @@ const sidebarStyle = (isMobile: boolean, active: boolean) => css`
   ${isMobile &&
   css`
     cursor: default;
-    position: absolute;
+    position: fixed;
     background: #f8f8f9;
     width: 100%;
     top: 84px;

--- a/src/components/organisms/Sidebar.tsx
+++ b/src/components/organisms/Sidebar.tsx
@@ -5,6 +5,7 @@ import { SectionItem, SectionList } from 'hooks/api/useGetSections'
 import media from 'lib/styles/media'
 import { useRouter } from 'next/dist/client/router'
 import Link from 'next/link'
+import { useEffect } from 'react'
 
 import { useToggle } from '../../hooks/useToggle'
 import palette from '../../lib/styles/palette'
@@ -28,6 +29,15 @@ function Sidebar({
   const courseId = router.query.courseId
   const [toggle, set] = useToggle(false)
 
+
+  useEffect(() => {
+    // 사이드바가 열렸을 때 상위영역 스크롤 방지
+    if(isMobile) {
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => document.body.removeAttribute('style');
+  }, [])
   return (
     <>
       <div css={sidebarStyle(isMobile, !router.query.sectionId)}>

--- a/src/components/organisms/Sidebar.tsx
+++ b/src/components/organisms/Sidebar.tsx
@@ -29,15 +29,15 @@ function Sidebar({
   const courseId = router.query.courseId
   const [toggle, set] = useToggle(false)
 
-
   useEffect(() => {
     // 사이드바가 열렸을 때 상위영역 스크롤 방지
-    if(isMobile) {
-      document.body.style.overflow = 'hidden';
+    if (isMobile) {
+      document.body.style.overflow = 'hidden'
     }
 
-    return () => document.body.removeAttribute('style');
+    return () => document.body.removeAttribute('style')
   }, [])
+
   return (
     <>
       <div css={sidebarStyle(isMobile, !router.query.sectionId)}>

--- a/src/components/templates/IntroSection.tsx
+++ b/src/components/templates/IntroSection.tsx
@@ -121,10 +121,9 @@ const containerStyle = css`
   box-sizing: border-box;
   padding-bottom: 100px;
   ${mediaQuery(767)} {
-    height: 100vh;
-    padding-left: 0;
-    padding-top: 94px;
-    padding-bottom: 150px;
+    padding: 0;
+    margin-top: 94px;
+    margin-bottom: 150px;
     overflow-y: auto;
     justify-content: center;
   }

--- a/src/components/templates/IntroSection.tsx
+++ b/src/components/templates/IntroSection.tsx
@@ -125,7 +125,7 @@ const containerStyle = css`
     padding-left: 0;
     padding-top: 94px;
     padding-bottom: 150px;
-    overflow: scroll;
+    overflow-y: auto;
     justify-content: center;
   }
 `

--- a/src/components/templates/LayoutResponsive.tsx
+++ b/src/components/templates/LayoutResponsive.tsx
@@ -18,9 +18,8 @@ function LayoutResponsive({
 }
 
 const layoutStyle = css`
-  margin-left: auto;
-  margin-right: auto;
   width: 1352px;
+  margin: 0 auto;
   ${mediaQuery(1440)} {
     width: 1280px;
   }

--- a/src/pages/course/[courseId]/[sectionId]/index.tsx
+++ b/src/pages/course/[courseId]/[sectionId]/index.tsx
@@ -206,14 +206,13 @@ const SectionPage = () => {
 
 const containerStyle = css`
   padding-left: 78px;
-  padding-top: 105px;
+  margin-top: 105px;
   box-sizing: border-box;
   padding-bottom: 30px;
   ${mediaQuery(767)} {
-    height: 100vh;
-    padding-left: 0;
-    padding-top: 94px;
-    padding-bottom: 150px;
+    padding: 0;
+    margin-top: 94px;
+    margin-bottom: 150px;
     overflow: scroll;
     justify-content: center;
   }


### PR DESCRIPTION
## 내용
<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

모바일 환경에서 2중 스크롤 현상 수정, (영상 사이즈가 커서 첨부가 안됩니다..)
아이폰 12 프로 사파리에서 X축 스크롤 생기는 현상 수정
![image](https://user-images.githubusercontent.com/20872150/125921832-0ebe9819-a265-47dc-a4f7-7a0fde5ae2ac.png)

2중 스크롤이 발생했던 이유는 다음과 같습니다.
1. 모바일 환경일 때 header에 가려지는 부분을 해결하려고 padding을 사용했습니다.
해결방법 : padding은 모바일 브라우저 환경에서 콘텐츠 영역에 일부분으로 보기 때문에 margin으로 변경해줬습니다. 
2. button에 postion이 absoulte인것과 height: 100vh로 되어있던 부분
해결방법 : button에 postion을 fixed로 변경과 동시에 100vh를 해제해줬습니다.

아이폰 12 프로 사파리에서 X축 스크롤이 생기는 현상에 이유는 다음과 같습니다.
1. 사파리에서 자동으로 X 축에 마진을 잡고 있었습니다.
해결방법 : margin-left, margin-right: auto 코드를 margin: 0 auto로 변경하면서 x축에 margin 값을 0으로 고정시켜줬습니다.

## 특별히 봐줬으면 하는 부분
2숭 스크롤이 발생하는 현상을 수정하면서 button에 position을 absolute에서 fixed로 변경하는 과정에서 사이드 이펙트가 생겨
Sidebar.tsx 파일에서 Mobile일 경우에 document.body에 scroll 을 hidden으로 고정시켜줬습니다.
<!-- 셀프 코멘트도 달아주세요! -->

## 참고 사항
<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->