### PR TITLE
feat: course section에서 string html을 출력할 수 있도록 수정

### DIFF
--- a/src/components/molecules/SectionRow.tsx
+++ b/src/components/molecules/SectionRow.tsx
@@ -14,9 +14,11 @@ function SectionRow({ title, description }: SectionRowProps) {
         <Text as="h6">{title}</Text>
       </div>
       {description && (
-        <Text as="p" css={descriptionStyle}>
-          {description}
-        </Text>
+        <Text
+          as="p"
+          css={descriptionStyle}
+          dangerouslySetInnerHTML={{ __html: description }}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## 내용

<img width="761" alt="스크린샷 2021-07-26 오후 2 58 58" src="https://user-images.githubusercontent.com/20872150/126940087-7ea4dbd2-6768-4196-ace7-b97e39034d01.png">

1. 추가된 기능
- 코스 섹션에 description은 서버로부터 데이터를 받아옵니다. 이 과정에서 강조하고싶은 내용이 있는 부분이 있어 <strong>태그를 주입하는 경우를 대응하기 위해 기존 text를 return 하는 부분을 innerHtml을 사용해서 작업했습니다.
 
## 특별히 봐줬으면 하는 부분

`dangerouslySetInnerHTML` 를 사용했는데 위험하다는 말이 많긴한데 어쩔 수 없이 사용했습니다!
`dangerouslySetInnerHTML` 말고 대응할 수 있는 방법이 있을까요?

## 참고 사항