### PR TITLE
fix: course 메인로고 겹치는 현상수정

### DIFF
--- a/src/pages/course/[courseSlug]/[sectionSlug]/index.tsx
+++ b/src/pages/course/[courseSlug]/[sectionSlug]/index.tsx
@@ -16,8 +16,10 @@ import { mediaQuery } from 'lib/styles/media'
 import palette from 'lib/styles/palette'
 import { GetServerSideProps } from 'next'
 import Head from 'next/head'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { courseRedirectUrl } from 'utils/redirectUrl'
+
+import { useWindowSize } from '../../../../hooks/useWindow'
 
 const sectionPageLogger = logger.getPageLogger('section_page')
 
@@ -36,12 +38,18 @@ const SectionPage = () => {
 
   const { data } = useGetSections(courseSlug)
   const { data: sectionDetail } = useSectionDetail(courseSlug, sectionSlug)
+  const size = useWindowSize()
 
   const prevSectionLink =
     getSectionLink(courseSlug, sectionDetail?.prevSection) ??
     generateSectionLink(courseSlug, '')
 
   const nextSectionLink = getSectionLink(courseSlug, sectionDetail?.nextSection)
+
+  const [mobile, set] = useState<boolean>(false)
+  useEffect(() => {
+    size.width <= 786 ? set(true) : set(false)
+  }, [size.width])
 
   const handleSectionItemClick = useCallback(
     ({ urlSlug, title }: SectionItem) => {
@@ -111,10 +119,12 @@ const SectionPage = () => {
         />
         <meta name="description" content={sectionDetail.description} />
       </Head>
-      <MobileSectionHeader
-        sectionList={data}
-        courseName={data.curriculum.title}
-      />
+      {mobile && (
+        <MobileSectionHeader
+          sectionList={data}
+          courseName={data.curriculum.title}
+        />
+      )}
       <LayoutResponsive>
         <Layout>
           <Layout.Side>


### PR DESCRIPTION
## 내용
- Introsection 에서는 메인 로고 모바일 로고 분리 했으나
- course section 에서 메인로고 모바일 로고 충돌 현상 수정