### PR TITLE
fix: 404 페이지에 위치가 정확하게 보이지 않던 이슈 수정

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -59,6 +59,6 @@ const wrapperStyle = css`
   position: absolute;
   left: 50%;
   top: 50%;
-  translate: -50% -50%;
+  transform: translate(-50%, -50%);
   text-align: center;
 `


### PR DESCRIPTION
## 내용
<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

<img width="2088" alt="스크린샷 2021-09-12 오전 2 47 40" src="https://user-images.githubusercontent.com/20872150/132956690-b85aa4eb-994d-4710-8cb3-2bc4f1fa979e.png">

1. translate가 적용되지 않던 이슈를 수정했습니다.
수정 방법 기존 translate만 css에 적용했는데 이 부분을
```
 transform: translate(-50%, -50%)
```
## 특별히 봐줬으면 하는 부분

## 참고 사항
