### PR TITLE
Fix/리다이렉트시 한글 URL로 안되는 버그 수정

### DIFF
--- a/src/utils/redirectUrl.ts
+++ b/src/utils/redirectUrl.ts
@@ -137,12 +137,14 @@ const redirectMap: RedirectMap = {
     '/course/typescript-usage/typescript-react-redux-사용하기',
 }
 
-const isValidCourseUrl = (url: string) => /\/course\/(\d+)/.test(url)
-
 export const courseRedirectUrl = (context: GetServerSidePropsContext) => {
-  if (isValidCourseUrl(context.resolvedUrl)) {
+  const valid = Object.keys(redirectMap).includes(context.resolvedUrl)
+
+  if (valid) {
     const { res } = context
-    res.writeHead(301, { location: redirectMap[context.resolvedUrl] ?? '/' })
+    res.writeHead(301, {
+      location: encodeURI(redirectMap[context.resolvedUrl]) ?? '/',
+    })
     res.end()
   }
 


### PR DESCRIPTION
## 내용
배포 되었던 URL slug 변경 코드에서 한글이 추가되면서 redirect시 찾지 못하는 이슈가 있어 encodeURL을 추가해줬습니다.

## 특별히 봐줬으면 하는 부분

## 참고 사항
테스트할때 됐었는데 적용이 안된 시점에서 테스트했나보네요 ㅠㅠ 다음부터는 테스트 더 꼼꼼하게 하겠습니다.