### PR TITLE
fix: favicon url 호출 방식 수정, og content 보완

### DIFF
--- a/src/pages/course/[courseSlug]/[sectionSlug]/index.tsx
+++ b/src/pages/course/[courseSlug]/[sectionSlug]/index.tsx
@@ -138,6 +138,12 @@ const SectionPage = () => {
           content={sectionDetail.blogs.map((e) => e.title).join(', ')}
         />
         <meta name="description" content={sectionDetail.description} />
+        <meta property="og:title" content={`clelab - ${sectionDetail.title}`} />
+        <meta
+          property="og:description"
+          content={sectionDetail.description}
+        />
+        <meta property="og:image" content={sectionDetail.thumbnail} />
       </Head>
       {mobile && (
         <MobileSectionHeader

--- a/src/pages/course/[courseSlug]/[sectionSlug]/index.tsx
+++ b/src/pages/course/[courseSlug]/[sectionSlug]/index.tsx
@@ -139,10 +139,7 @@ const SectionPage = () => {
         />
         <meta name="description" content={sectionDetail.description} />
         <meta property="og:title" content={`clelab - ${sectionDetail.title}`} />
-        <meta
-          property="og:description"
-          content={sectionDetail.description}
-        />
+        <meta property="og:description" content={sectionDetail.description} />
         <meta property="og:image" content={sectionDetail.thumbnail} />
       </Head>
       {mobile && (

--- a/src/pages/course/[courseSlug]/index.tsx
+++ b/src/pages/course/[courseSlug]/index.tsx
@@ -69,7 +69,10 @@ const CoursePage = () => {
         <script type="application/ld+json">{JSON.stringify(schemaData)}</script>
         <meta name="keywords" content={data.curriculum.title} />
         <meta name="description" content={data.intro.description.summary} />
-        <meta property="og:title" content={`clelab - ${data.curriculum.title}`} />
+        <meta
+          property="og:title"
+          content={`clelab - ${data.curriculum.title}`}
+        />
         <meta
           property="og:description"
           content={data.intro.description.summary}

--- a/src/pages/course/[courseSlug]/index.tsx
+++ b/src/pages/course/[courseSlug]/index.tsx
@@ -69,6 +69,12 @@ const CoursePage = () => {
         <script type="application/ld+json">{JSON.stringify(schemaData)}</script>
         <meta name="keywords" content={data.curriculum.title} />
         <meta name="description" content={data.intro.description.summary} />
+        <meta property="og:title" content={`clelab - ${data.curriculum.title}`} />
+        <meta
+          property="og:description"
+          content={data.intro.description.summary}
+        />
+        <meta property="og:image" content={data.thumbnail} />
       </Head>
       {mobile && (
         <MobileSectionHeader

--- a/src/utils/favicon.ts
+++ b/src/utils/favicon.ts
@@ -1,5 +1,3 @@
 export function getFaviconUrl(url: string) {
-  const arr = url.split('/')
-
-  return arr[0] + '//' + arr[2] + '/favicon.ico'
+  return `https://s2.googleusercontent.com/s2/favicons?domain=${url}`
 }


### PR DESCRIPTION
## 내용
- favicon 을 잘못 가져오는 내용이 있어서 보완
[선영님이 찾은 url](https://mattermost.lubycon.io/lubycon/pl/34pa956imbgij8y1wsoxh9djkw)로 보완
- 코스, section 링크 공유시 코스 및 섹션 open graph meta tag 적용
